### PR TITLE
Issues notifications only for issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
     description: "Comma-separated labels that should exclude the issue"
     required: false
     default: ""
+  
+  # Only check issues, not pull requests
+  issues_only:
+    description: "Only check issues, not pull requests"
+    required: false
+    default: "true"
 
   # Thresholds
   reaction_threshold:

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -19,6 +19,7 @@ describe("IssueNotificationAction", () => {
         title_keywords: "",
         required_labels: "",
         excluded_labels: "",
+        issues_only: "false",
         reaction_threshold: "5",
         comment_threshold: "3",
         message_template: "Test message {title}",
@@ -129,5 +130,83 @@ describe("IssueNotificationAction", () => {
     };
 
     expect(action.shouldNotifyForThresholds(issue)).toBe(true);
+  });
+
+  test("should notify for regular issues when issues_only is false", () => {
+    core.getInput.mockImplementation((name) => {
+      if (name === "issues_only") return "false";
+      return "";
+    });
+
+    const { IssueNotificationAction } = require("../index");
+    const action = new IssueNotificationAction();
+
+    const issue = {
+      title: "Test issue",
+      labels: [],
+      reactions: { total_count: 20 },
+      comments: 2,
+    };
+
+    expect(action.shouldNotifyForIssue(issue)).toBe(true);
+  });
+
+  test("should notify for pull requests when issues_only is false", () => {
+    core.getInput.mockImplementation((name) => {
+      if (name === "issues_only") return "false";
+      return "";
+    });
+
+    const { IssueNotificationAction } = require("../index");
+    const action = new IssueNotificationAction();
+
+    const pullRequest = {
+      title: "Test pull request",
+      labels: [],
+      reactions: { total_count: 20 },
+      comments: 2,
+      pull_request: {}, // This indicates it's a pull request
+    };
+
+    expect(action.shouldNotifyForIssue(pullRequest)).toBe(true);
+  });
+
+  test("should notify for regular issues when issues_only is true", () => {
+    core.getInput.mockImplementation((name) => {
+      if (name === "issues_only") return "true";
+      return "";
+    });
+
+    const { IssueNotificationAction } = require("../index");
+    const action = new IssueNotificationAction();
+
+    const issue = {
+      title: "Test issue",
+      labels: [],
+      reactions: { total_count: 20 },
+      comments: 2,
+    };
+
+    expect(action.shouldNotifyForIssue(issue)).toBe(true);
+  });
+
+  test("should not notify for pull requests when issues_only is true", () => {
+    core.getInput.mockImplementation((name) => {
+      if (name === "issues_only") return "true";
+      return "";
+    });
+
+    const { IssueNotificationAction } = require("../index");
+    const action = new IssueNotificationAction();
+
+    const pullRequest = {
+      title: "Test pull request",
+      labels: [],
+      reactions: { total_count: 20 },
+      comments: 20,
+      pull_request: {}, // This indicates it's a pull request
+    };
+
+    expect(action.shouldNotifyForIssue(pullRequest)).toBe(false);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ class IssueNotificationAction {
       .split(",")
       .map((l) => l.trim())
       .filter((l) => l);
+    this.issuesOnly = core.getInput("issues_only") === "true";
     this.reactionThreshold = parseInt(core.getInput("reaction_threshold")) || 5;
     this.commentThreshold = parseInt(core.getInput("comment_threshold")) || 3;
     this.messageTemplate = core.getInput("message_template");
@@ -167,6 +168,12 @@ class IssueNotificationAction {
   }
 
   shouldNotifyForIssue(issue) {
+    // Skip if issues_only is true and issue is a pull request
+    if (this.issuesOnly && issue.pull_request) {
+      core.info(`Issue ${issue.number} is a pull request, skipping due to issues_only setting`);
+      return false;
+    }
+
     // Check title keywords
     if (this.titleKeywords.length > 0) {
       const titleLower = issue.title.toLowerCase();


### PR DESCRIPTION
Adds `issues_only` parameter (defaulting to `true`) to allow having notification only for issues

Used `pull_request` parameter based on this documentation:
https://docs.github.com/en/actions/reference/events-that-trigger-workflows?utm_source=chatgpt.com#issue_comment-on-issues-only-or-pull-requests-only